### PR TITLE
Enable coming soon mode

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_SITE_MODE=development

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_SITE_MODE=production

--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ You can deploy this template instantly using [Vercel](https://vercel.com), the p
 4. **Set Environment Variables (if needed)**
    If your project uses any `.env.local` values, you can configure them under **Settings > Environment Variables** in your Vercel dashboard.
 
+   This template also supports a simple `NEXT_PUBLIC_SITE_MODE` variable to
+   switch between `development` and `production` modes. Use `.env.development`
+   for your dev branch and `.env.production` for the live site.
+
 5. **Build the Project Locally (Optional but Recommended)**
    Run the build locally to make sure everything compiles before deploying:
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,5 +1,6 @@
 import Web3ContactForm from "@/components/ContactForm/ContactForm";
 import PageLayout from "@/components/Layouts/PageLayout";
+import { redirectIfProduction } from "@/utils/redirectIfProduction";
 import {
   EnvelopeIcon,
   PhoneIcon,
@@ -7,6 +8,7 @@ import {
 } from "@heroicons/react/24/outline";
 
 export default function Contact() {
+  redirectIfProduction();
   return (
     <section id="contact">
       <PageLayout>

--- a/src/app/notfound/page.tsx
+++ b/src/app/notfound/page.tsx
@@ -5,8 +5,16 @@ import { motion } from "framer-motion";
 import { FaGhost } from "react-icons/fa";
 import IconWrapper from "@/components/IconWrapper/IconWrapper";
 import PageLayout from "@/components/Layouts/PageLayout";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 
 export default function NotFound() {
+  const router = useRouter();
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_SITE_MODE === "production") {
+      router.replace("/comingsoon");
+    }
+  }, [router]);
   return (
     <PageLayout noPadding fullHeight>
       <div className="flex flex-col items-center justify-center">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,8 +4,10 @@ import AnimatedGradientBackground from "@/components/GradientBackground/Animated
 import HeroSection from "@/components/HeroSection/HeroSection";
 import InfoCard from "@/components/InfoCard/InfoCard";
 import PageLayout from "@/components/Layouts/PageLayout";
+import { redirectIfProduction } from "@/utils/redirectIfProduction";
 
 export default function Home() {
+  redirectIfProduction();
   return (
     <>
       <section id="home" className="relative bg-neutral">

--- a/src/app/servererror/page.tsx
+++ b/src/app/servererror/page.tsx
@@ -6,11 +6,13 @@ import { MdErrorOutline } from "react-icons/md";
 import { useEffect, useState } from "react";
 import { TailSpin } from "react-loader-spinner"; // Or your own Spinner
 import { IconBaseProps } from "react-icons";
+import { useRouter } from "next/navigation";
 
 const ErrorIcon = MdErrorOutline as unknown as React.FC<IconBaseProps>;
 
 export default function ServerErrorPage() {
   const [showPage, setShowPage] = useState(false);
+  const router = useRouter();
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -18,6 +20,12 @@ export default function ServerErrorPage() {
     }, 1000); // Show loader for 1s
     return () => clearTimeout(timer);
   }, []);
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_SITE_MODE === "production") {
+      router.replace("/comingsoon");
+    }
+  }, [router]);
 
   if (!showPage) {
     return (

--- a/src/utils/redirectIfProduction.ts
+++ b/src/utils/redirectIfProduction.ts
@@ -1,0 +1,7 @@
+import { redirect } from 'next/navigation';
+
+export function redirectIfProduction() {
+  if (process.env.NEXT_PUBLIC_SITE_MODE === 'production') {
+    redirect('/comingsoon');
+  }
+}


### PR DESCRIPTION
## Summary
- add `redirectIfProduction` helper and use it in pages
- add dev and production `.env` files to control site mode
- redirect fallback pages when in production mode
- document `NEXT_PUBLIC_SITE_MODE` in README

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686114d39bd8832d85f48d5c3ab761b4