### PR TITLE
Add split nav variant

### DIFF
--- a/src/components/ClientNav/ClientNav.tsx
+++ b/src/components/ClientNav/ClientNav.tsx
@@ -39,7 +39,7 @@ export default function ClientNav() {
         showNavigation,
       }}
       navMode="single"
-      variant="standard"
+      variant="split"
       transparent={true}
       glassMorphism={true}
       showThemeSwitcher={false}
@@ -51,7 +51,7 @@ export default function ClientNav() {
       }}
       mobileFullScreen={true}
       cta={{
-        show: true,
+        show: false,
         text: "Get in Touch",
         href: "/contact",
       }}

--- a/src/components/Navbar/ConfigurableNav/ConfigurableNav.tsx
+++ b/src/components/Navbar/ConfigurableNav/ConfigurableNav.tsx
@@ -137,13 +137,13 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
 
   // Detect scroll for split variant
   useEffect(() => {
-    if (variant !== "split") return;
+    if (variant !== "split" || !transparent) return;
     const onScroll = () => {
-      setScrolled(window.scrollY > 0);
+      setScrolled(window.scrollY > 10);
     };
     window.addEventListener("scroll", onScroll);
     return () => window.removeEventListener("scroll", onScroll);
-  }, [variant]);
+  }, [variant, transparent]);
 
   // Handle body scroll when mobile menu is open
   useEffect(() => {
@@ -213,9 +213,21 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
         styles.mobileMenu.container = "bg-elements-primary-shadow";
         break;
       case "split":
-        styles.container = scrolled
-          ? "backdrop-blur-md bg-card-background/70 border-b border-border-dimmed shadow-lg"
-          : "bg-transparent";
+        if (transparent && glassMorphism) {
+          styles.container = scrolled
+            ? "backdrop-blur-md bg-card-background/70 border-b border-border-dimmed shadow-lg transition-all duration-300"
+            : "bg-transparent transition-all duration-300";
+        } else if (transparent && !glassMorphism) {
+          styles.container = scrolled
+            ? "bg-card-background border-b border-border-dimmed shadow-lg transition-all duration-300"
+            : "bg-transparent transition-all duration-300";
+        } else if (!transparent && glassMorphism) {
+          styles.container =
+            "backdrop-blur-md bg-card-background/70 border-b border-border-dimmed shadow-lg";
+        } else {
+          styles.container =
+            "bg-card-background border-b border-border-dimmed shadow-lg";
+        }
         styles.wrapper = "sticky top-0 z-50 w-full";
         styles.navItem.active = "text-text-primary";
         styles.navItem.inactive =
@@ -262,9 +274,15 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
 
   const styles = getNavStyles();
 
-  const midIndex = Math.ceil(navigationItems.length / 2);
-  const leftItems = navigationItems.slice(0, midIndex);
-  const rightItems = navigationItems.slice(midIndex);
+  // For split variant, divide navigation items into left and right groups
+  const leftItems =
+    variant === "split"
+      ? navigationItems.slice(0, 2)
+      : navigationItems.slice(0, Math.ceil(navigationItems.length / 2));
+  const rightItems =
+    variant === "split"
+      ? navigationItems.slice(2, 4)
+      : navigationItems.slice(Math.ceil(navigationItems.length / 2));
 
   // Logo component
   const LogoComponent = () => {
@@ -286,7 +304,7 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
 
   // CTA Button component
   const CTAButton = () => {
-    if (!cta.show) return null;
+    if (!cta.show || variant === "split") return null;
 
     return (
       <Link
@@ -723,21 +741,22 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
             <div className="flex h-20 items-center justify-between w-full">
               {variant === "split" ? (
                 <>
-                  <div className="hidden sm:flex items-center space-x-8">
+                  <div className="hidden sm:flex items-center space-x-8 flex-1">
                     {leftItems.map(renderNavItem)}
                   </div>
-                  <div className="flex flex-shrink-0 items-center z-10 mx-4">
+                  <div className="flex flex-shrink-0 items-center justify-center z-10 mx-4">
                     <Link href="/" className="relative z-10">
                       <LogoComponent />
                     </Link>
                   </div>
-                  <div className="hidden sm:flex items-center space-x-8">
+                  <div className="hidden sm:flex items-center space-x-8 flex-1 justify-end">
                     {rightItems.map(renderNavItem)}
                   </div>
-                  <div className="hidden sm:flex items-center gap-4 ml-4">
-                    {showThemeSwitcher && <ThemeSwitcher />}
-                    <CTAButton />
-                  </div>
+                  {showThemeSwitcher && (
+                    <div className="hidden sm:flex items-center ml-4">
+                      <ThemeSwitcher />
+                    </div>
+                  )}
                 </>
               ) : (
                 <>

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -8,6 +8,7 @@ import {
   LuCalendarDays,
   LuPhone,
   LuUtensilsCrossed,
+  LuMapPin,
 } from "react-icons/lu";
 
 // Define navigation item structure
@@ -31,20 +32,10 @@ export function useNavigationConfig(): {
 
   const navigationItems: NavigationItem[] = useMemo(
     () => [
-      // {
-      //   name: "",
-      //   sectionId: "home",
-      //   path: "/",
-      //   current: pathname === "/",
-      //   icon: LuHouse,
-      // },
-      {
-        name: "Menu",
-        sectionId: "menu",
-        path: "/menu",
-        current: pathname === "/menu",
-        icon: LuUtensilsCrossed,
-      },
+      { name: "About", path: "/about", current: pathname === "/about", icon: LuInfo },
+      { name: "Catering", path: "/catering", current: pathname === "/catering", icon: LuUtensilsCrossed },
+      { name: "Menu", path: "/menu", current: pathname === "/menu", icon: LuUtensilsCrossed },
+      { name: "Find Us", path: "/find-us", current: pathname === "/find-us", icon: LuMapPin },
     ],
     [pathname]
   );
@@ -61,8 +52,10 @@ export const mainNavigation: {
   showNavigation: boolean;
 } = {
   navigationItems: [
-    // { name: "Home", sectionId: "home", path: "/", current: true },
-    { name: "Menu", sectionId: "menu", path: "/menu", current: false },
+    { name: "About", path: "/about", current: false },
+    { name: "Catering", path: "/catering", current: false },
+    { name: "Menu", path: "/menu", current: false },
+    { name: "Find Us", path: "/find-us", current: false },
   ],
   showNavigation: true,
 };
@@ -72,8 +65,10 @@ export const minimalistNavigation: {
   showNavigation: boolean;
 } = {
   navigationItems: [
-    // { name: "Home", sectionId: "home", path: "/", current: true },
-    { name: "Menu", sectionId: "menu", path: "/menu", current: false },
+    { name: "About", path: "/about", current: false },
+    { name: "Catering", path: "/catering", current: false },
+    { name: "Menu", path: "/menu", current: false },
+    { name: "Find Us", path: "/find-us", current: false },
   ],
   showNavigation: true,
 };
@@ -83,8 +78,10 @@ export const fullNavigation: {
   showNavigation: boolean;
 } = {
   navigationItems: [
-    // { name: "Home", sectionId: "home", path: "/", current: true },
-    { name: "Menu", sectionId: "menu", path: "/menu", current: false },
+    { name: "About", path: "/about", current: false },
+    { name: "Catering", path: "/catering", current: false },
+    { name: "Menu", path: "/menu", current: false },
+    { name: "Find Us", path: "/find-us", current: false },
   ],
   showNavigation: true,
 };


### PR DESCRIPTION
## Summary
- add `split` navigation variant for centered logo with nav items left and right
- detect scroll to toggle glass background on the new nav variant
- update navigation config with About, Catering, Menu and Find Us

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863fb4462d8832da218ef4118501a40