### PR TITLE
Fix split mobile nav

### DIFF
--- a/src/components/Navbar/ConfigurableNav/ConfigurableNav.tsx
+++ b/src/components/Navbar/ConfigurableNav/ConfigurableNav.tsx
@@ -147,7 +147,7 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
 
   // Handle body scroll when mobile menu is open
   useEffect(() => {
-    if (mobileMenuOpen && mobileFullScreen) {
+    if (mobileMenuOpen) {
       document.body.style.overflow = "hidden";
     } else {
       document.body.style.overflow = "";
@@ -155,7 +155,7 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
     return () => {
       document.body.style.overflow = "";
     };
-  }, [mobileMenuOpen, mobileFullScreen]);
+  }, [mobileMenuOpen]);
 
   // Exit early if navigation should not be shown
   if (!showNavigation) return null;
@@ -237,7 +237,7 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
             "text-text-clear hover:text-elements-secondary-main";
           styles.mobileMenu.container =
             variant === "split"
-              ? "fixed inset-0 backdrop-blur-xl bg-black/60 z-50"
+              ? "fixed inset-0 backdrop-blur-xl bg-black/60 z-40"
               : "bg-elements-primary-shadow";
         }
         break;
@@ -725,7 +725,10 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
 
     return (
       <button
-        className="inline-flex items-center justify-center rounded-md p-2 text-text-secondary focus:outline-none"
+        className={classNames(
+          "inline-flex items-center justify-center rounded-md p-2 focus:outline-none",
+          styles.navItem.inactive
+        )}
         onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
       >
         <span className="sr-only">
@@ -856,7 +859,7 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
                 transition={{ duration: 0.3 }}
                 className={classNames(
                   variant === "split"
-                    ? "fixed inset-0 backdrop-blur-xl bg-black/60 z-50 flex items-center justify-center"
+                    ? "fixed inset-0 backdrop-blur-xl bg-black/60 z-40 flex items-center justify-center"
                     : mobileFullScreen
                     ? "fixed inset-x-0 top-20 bottom-0 z-40 flex flex-col"
                     : "sm:hidden",

--- a/src/components/Navbar/ConfigurableNav/ConfigurableNav.tsx
+++ b/src/components/Navbar/ConfigurableNav/ConfigurableNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
 import { LuMenu, LuX, LuChevronDown, LuPhone } from "react-icons/lu";
 import Link from "next/link";
 import Image from "next/image";
@@ -78,6 +78,7 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState<string | null>(null);
   const [mounted, setMounted] = useState(false);
+  const scrollLockPosition = useRef(0);
   const [scrolled, setScrolled] = useState(false);
   const { resolvedTheme, setTheme } = useTheme();
 
@@ -148,11 +149,22 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
   // Handle body scroll when mobile menu is open
   useEffect(() => {
     if (mobileMenuOpen) {
+      scrollLockPosition.current = window.scrollY;
+      document.body.style.position = "fixed";
+      document.body.style.top = `-${scrollLockPosition.current}px`;
+      document.body.style.width = "100%";
       document.body.style.overflow = "hidden";
     } else {
+      document.body.style.position = "";
+      document.body.style.top = "";
+      document.body.style.width = "";
       document.body.style.overflow = "";
+      window.scrollTo(0, scrollLockPosition.current);
     }
     return () => {
+      document.body.style.position = "";
+      document.body.style.top = "";
+      document.body.style.width = "";
       document.body.style.overflow = "";
     };
   }, [mobileMenuOpen]);
@@ -215,8 +227,10 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
         // Apply glassMorphism styling if enabled or when scrolled,
         // otherwise use transparent/solid background
         if (glassMorphism || scrolled) {
-          styles.container =
-            "backdrop-blur-md bg-black/40 transition-all duration-300 ease-in-out border-b border-gray-200/20";
+          styles.container = classNames(
+            "relative z-50",
+            "backdrop-blur-md bg-black/40 transition-all duration-300 ease-in-out border-b border-gray-200/20"
+          );
           styles.navItem.active = "text-text-primary";
           styles.navItem.inactive = [
             "text-text-clear",
@@ -229,9 +243,12 @@ const ConfigurableNavigation: React.FC<NavProps> = ({
               ? "backdrop-blur-md bg-black/40 border-t border-white/10"
               : "bg-card-background/80 backdrop-blur-md transition-all duration-300 ease-in-out";
         } else {
-          styles.container = transparent
-            ? "bg-transparent transition-all duration-300 ease-in-out border-b border-gray-200/30"
-            : "bg-neutral-dimmed-heavy transition-all duration-300 ease-in-out border-b border-gray-200/30";
+          styles.container = classNames(
+            "relative z-50",
+            transparent
+              ? "bg-transparent transition-all duration-300 ease-in-out border-b border-gray-200/30"
+              : "bg-neutral-dimmed-heavy transition-all duration-300 ease-in-out border-b border-gray-200/30"
+          );
           styles.navItem.active = "text-text-clear";
           styles.navItem.inactive =
             "text-text-clear hover:text-elements-secondary-main";


### PR DESCRIPTION
## Summary
- stop mobile scrolling when menu is open
- keep header above the mobile menu overlay and match hamburger color

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68641762ee20832d8763cab601acb7c7