### PR TITLE
Fix single quote handling

### DIFF
--- a/src/components/InfoCard/InfoCard.tsx
+++ b/src/components/InfoCard/InfoCard.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { escapeSingleQuotes } from "@/lib/utils";
 
 const InfoCard = () => {
   return (
@@ -20,9 +21,9 @@ const InfoCard = () => {
           <div className="mb-8">
             <div className="text-text-secondary leading-relaxed space-y-4">
               <p className="text-lg">
-                Nestled in the vibrant heart of Southall, Yellow Chilli is more
-                than just a restaurant—it's a celebration of India's rich
-                culinary heritage blended with the bold flavors of Afghanistan.
+                {escapeSingleQuotes(
+                  "Nestled in the vibrant heart of Southall, Yellow Chilli is more than just a restaurant—it's a celebration of India's rich culinary heritage blended with the bold flavors of Afghanistan."
+                )}
               </p>
               <p>
                 Our kitchen tells stories through spices, where every dish is
@@ -32,10 +33,9 @@ const InfoCard = () => {
                 your soul.
               </p>
               <p>
-                Whether you're gathering with family, celebrating with friends,
-                or discovering new tastes, Yellow Chilli welcomes you to
-                experience the true essence of South Asian hospitality—where
-                every meal is a journey and every guest becomes family.
+                {escapeSingleQuotes(
+                  "Whether you're gathering with family, celebrating with friends, or discovering new tastes, Yellow Chilli welcomes you to experience the true essence of South Asian hospitality—where every meal is a journey and every guest becomes family."
+                )}
               </p>
             </div>
           </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,7 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function escapeSingleQuotes(str: string): string {
+  return str.replace(/'/g, "\\'")
+}

--- a/themes/utils/getInstance.js
+++ b/themes/utils/getInstance.js
@@ -1,4 +1,5 @@
-const instance = process.env.REACT_APP_INSTANCE_NAME
+const rawInstance = process.env.REACT_APP_INSTANCE_NAME
+const instance = rawInstance ? rawInstance.replace(/'/g, "\\'") : undefined
 
 const getInstance = () => {
   return instance


### PR DESCRIPTION
## Summary
- add utility to escape single quotes
- sanitize text in `InfoCard`
- sanitize environment variable in theme instance util

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68650a01e8c0832da71023607ec7fb79