### PR TITLE
Configure dev URL and SEO

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_SITE_MODE=development
+NEXT_PUBLIC_SITE_URL=https://your-dev-url.vercel.app

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_SITE_MODE=development
+NEXT_PUBLIC_SITE_URL=https://your-project-name.vercel.app

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_SITE_MODE=production
+NEXT_PUBLIC_SITE_URL=https://yellowchilli.co.uk

--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ You can deploy this template instantly using [Vercel](https://vercel.com), the p
    switch between `development` and `production` modes. Use `.env.development`
    for your dev branch and `.env.production` for the live site.
 
+   For preview deployments, set `NEXT_PUBLIC_SITE_URL` to your Vercel preview
+   URL (e.g. `https://your-project-name.vercel.app`) and keep
+   `NEXT_PUBLIC_SITE_MODE=development` so the full site is accessible.
+
 5. **Build the Project Locally (Optional but Recommended)**
    Run the build locally to make sure everything compiles before deploying:
 
@@ -263,7 +267,7 @@ export default function AboutPage() {
       <SEO
         title="About Us"
         description="Learn more about our mission and team."
-        url="https://yellowchilli.co.uk/about"
+        url={`${process.env.NEXT_PUBLIC_SITE_URL}/about`}
         image="/images/about-og.jpg"
         keywords={["About", "Company", "Team"]}
       />

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
-  siteUrl: "https://yellowchilli.co.uk", // 🔁 Replace with your actual domain (no trailing slash)
+  siteUrl: process.env.NEXT_PUBLIC_SITE_URL || "https://yellowchilli.co.uk", // 🔁 Replace with your actual domain (no trailing slash)
   generateRobotsTxt: true, // ✅ Generate robots.txt file
   changefreq: "weekly", // Optional: change frequency for crawlers
   priority: 0.7, // Optional: priority for pages
@@ -19,8 +19,8 @@ module.exports = {
       },
     ],
     additionalSitemaps: [
-      "https://yellowchilli.co.uk/sitemap-0.xml",
-      // "https://yellowchilli.co.uk/extra-sitemap.xml", // Add any custom ones here
+      `${process.env.NEXT_PUBLIC_SITE_URL || "https://yellowchilli.co.uk"}/sitemap-0.xml`,
+      // `${process.env.NEXT_PUBLIC_SITE_URL || "https://yellowchilli.co.uk"}/extra-sitemap.xml`, // Add any custom ones here
     ],
   },
 };

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -65,10 +65,10 @@ export default function Contact() {
                   </dt>
                   <dd>
                     <a
-                      href="mailto:hello@example.com"
+                      href="mailto:hello@yellowchilli.co.uk"
                       className="hover:text-gray-900"
                     >
-                      hello@example.com
+                      hello@yellowchilli.co.uk
                     </a>
                   </dd>
                 </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,12 +19,12 @@ export const metadata: Metadata = {
     "South Asian food Southall",
     "tandoori grill Southall",
   ],
-  metadataBase: new URL("https://yellowchilli.co.uk"),
+  metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL || "https://yellowchilli.co.uk"),
   openGraph: {
     title: "Yellow Chilli | Indian & Afghan Cuisine in Southall",
     description:
       "Discover the rich flavours of Indian and Afghan cuisine at Yellow Chilli in Southall. From aromatic biryanis to sizzling grills, enjoy authentic dishes in a warm, welcoming setting.",
-    url: "https://yellowchilli.co.uk",
+    url: process.env.NEXT_PUBLIC_SITE_URL || "https://yellowchilli.co.uk",
     siteName: "Yellow Chilli",
     images: [
       {

--- a/src/app/metadata.ts
+++ b/src/app/metadata.ts
@@ -17,12 +17,12 @@ export const metadata: Metadata = {
     "South Asian food Southall",
     "tandoori grill Southall",
   ],
-  metadataBase: new URL("https://yellowchilli.co.uk"),
+  metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL || "https://yellowchilli.co.uk"),
   openGraph: {
     title: "Yellow Chilli | Indian & Afghan Cuisine in Southall",
     description:
       "Discover the rich flavours of Indian and Afghan cuisine at Yellow Chilli in Southall. From aromatic biryanis to sizzling grills, enjoy authentic dishes in a warm, welcoming setting.",
-    url: "https://yellowchilli.co.uk",
+    url: process.env.NEXT_PUBLIC_SITE_URL || "https://yellowchilli.co.uk",
     siteName: "Yellow Chilli",
     images: [
       {

--- a/src/components/SEO/SEO.tsx
+++ b/src/components/SEO/SEO.tsx
@@ -14,7 +14,7 @@ const defaultMetadata = {
   title: "Yellow Chilli | Indian & Afghan Cuisine in Southall",
   description:
     "Discover the rich flavours of Indian and Afghan cuisine at Yellow Chilli in Southall. From aromatic biryanis to sizzling grills, enjoy authentic dishes in a warm, welcoming setting.",
-  url: "https://yellowchilli.co.uk",
+  url: process.env.NEXT_PUBLIC_SITE_URL || "https://yellowchilli.co.uk",
   image: "/images/og-default.png",
   keywords: [
     "Yellow Chilli Southall",


### PR DESCRIPTION
## Summary
- remove all example.com references
- showcase environment variable usage in README snippet
- keep production links pointing to yellowchilli.co.uk

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e89b1e3c832d97b449bbd741a7be