### PR TITLE
Remove unused OurStory carousel

### DIFF
--- a/src/components/OurStory/OurStory.tsx
+++ b/src/components/OurStory/OurStory.tsx
@@ -84,7 +84,7 @@ const OurStory = () => {
       {/* Gradient Overlay */}
       <div className="absolute inset-0 bg-gradient-to-br from-elements-primary-main/3 via-transparent to-elements-primary-shadow/3 rounded-3xl" />
 
-      <div className="relative grid lg:grid-cols-2 gap-16 p-2 lg:p-20 items-center">
+      <div className="relative p-2 lg:p-20">
         {/* Left Side - Clean Text Content */}
         <motion.div className="space-y-10" variants={itemVariants}>
           {/* Title Section */}
@@ -253,97 +253,6 @@ const OurStory = () => {
           </motion.div>
         </motion.div>
 
-        {/* Right Side - Image Carousel */}
-        <motion.div className="relative" variants={itemVariants}>
-          {/* Main Image Container */}
-          <div className="relative h-[400px] sm:h-[600px] rounded-2xl overflow-hidden shadow-2xl bg-neutral-dimmed">
-            <AnimatePresence mode="wait">
-              <motion.div
-                key={currentImageIndex}
-                initial={{ opacity: 0, scale: 1.1 }}
-                animate={{ opacity: 1, scale: 1 }}
-                exit={{ opacity: 0, scale: 0.95 }}
-                transition={{ duration: 0.6, ease: "easeInOut" }}
-                className="absolute inset-0"
-              >
-                <img
-                  src={historyImages[currentImageIndex].image}
-                  alt={historyImages[currentImageIndex].alt}
-                  className="w-full h-full object-cover"
-                />
-                {/* Elegant Overlay */}
-                <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
-
-                {/* Image Info */}
-                <div className="absolute bottom-8 left-8 right-8 text-text-primary">
-                  <motion.div
-                    initial={{ y: 30, opacity: 0 }}
-                    animate={{ y: 0, opacity: 1 }}
-                    transition={{ delay: 0.3, duration: 0.6 }}
-                  >
-                    <h3 className="text-xl lg:text-2xl font-light mb-2 tracking-wide">
-                      {historyImages[currentImageIndex].title}
-                    </h3>
-                    <p className="text-text-primary/90 text-base font-medium mb-1">
-                      {historyImages[currentImageIndex].date}
-                    </p>
-                    <p className="text-text-primary/80 text-sm font-light">
-                      {historyImages[currentImageIndex].description}
-                    </p>
-                  </motion.div>
-                </div>
-              </motion.div>
-            </AnimatePresence>
-
-            {/* Navigation Arrows */}
-            <motion.button
-              onClick={prevImage}
-              className="absolute left-6 top-1/2 -translate-y-1/2 w-12 h-12 bg-white/15 backdrop-blur-md border border-white/25 rounded-full flex items-center justify-center text-text-primary hover:bg-white/25 transition-all duration-300"
-              whileHover={{ scale: 1.1 }}
-              whileTap={{ scale: 0.95 }}
-            >
-              <svg
-                className="w-5 h-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15 19l-7-7 7-7"
-                />
-              </svg>
-            </motion.button>
-
-            <motion.button
-              onClick={nextImage}
-              className="absolute right-6 top-1/2 -translate-y-1/2 w-12 h-12 bg-white/15 backdrop-blur-md border border-white/25 rounded-full flex items-center justify-center text-text-primary hover:bg-white/25 transition-all duration-300"
-              whileHover={{ scale: 1.1 }}
-              whileTap={{ scale: 0.95 }}
-            >
-              <svg
-                className="w-5 h-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9 5l7 7-7 7"
-                />
-              </svg>
-            </motion.button>
-          </div>
-
-          {/* Current Image Indicator */}
-          <div className="absolute top-6 right-6 bg-black/50 backdrop-blur-sm rounded-full px-3 py-1 text-text-primary text-xs font-medium">
-            {currentImageIndex + 1} / {historyImages.length}
-          </div>
-        </motion.div>
       </div>
     </motion.section>
   );


### PR DESCRIPTION
## Summary
- drop the OurStory carousel
- adjust the OurStory layout to a single column

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68691b534cf8832da73a3923b0de7a08