### PR TITLE
Improve SEO metadata

### DIFF
--- a/src/app/comingsoon/page.tsx
+++ b/src/app/comingsoon/page.tsx
@@ -2,6 +2,15 @@
 import React from "react";
 import Image from "next/image";
 import { motion } from "framer-motion";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Coming Soon",
+  description: "Yellow Chilli will be opening soon in Southall.",
+  alternates: {
+    canonical: "/comingsoon",
+  },
+};
 
 export default function ComingSoon(): JSX.Element {
   const containerVariants = {

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -5,6 +5,16 @@ import {
   PhoneIcon,
   BuildingOffice2Icon,
 } from "@heroicons/react/24/outline";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Contact Us",
+  description:
+    "Get in touch with Yellow Chilli to enquire about bookings or catering.",
+  alternates: {
+    canonical: "/contact",
+  },
+};
 
 export default function Contact() {
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -54,6 +54,9 @@ export const metadata: Metadata = {
       url: "/android-chrome-192x192.png",
     },
   },
+  alternates: {
+    canonical: "/",
+  },
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,16 @@ import InfoCard from "@/components/InfoCard/InfoCard";
 import PageLayout from "@/components/Layouts/PageLayout";
 import MenuSection from "@/components/MenuSection/MenuSection";
 import OurStory from "@/components/OurStory/OurStory";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Home",
+  description:
+    "Discover the rich flavours of Indian and Afghan cuisine at Yellow Chilli in Southall.",
+  alternates: {
+    canonical: "/",
+  },
+};
 
 export default function Home() {
   return (


### PR DESCRIPTION
## Summary
- add canonical URL to global layout
- provide per-page metadata with canonical links for the home, contact and coming soon pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68691fdb53fc832d8fd2abd8c628e686