### PR TITLE
Fix production mode redirect

### DIFF
--- a/src/app/notfound/page.tsx
+++ b/src/app/notfound/page.tsx
@@ -12,7 +12,7 @@ export default function NotFound() {
   const router = useRouter();
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_SITE_MODE === "production") {
-      router.replace("/comingsoon");
+      router.replace("/");
     }
   }, [router]);
   return (

--- a/src/app/servererror/page.tsx
+++ b/src/app/servererror/page.tsx
@@ -23,7 +23,7 @@ export default function ServerErrorPage() {
 
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_SITE_MODE === "production") {
-      router.replace("/comingsoon");
+      router.replace("/");
     }
   }, [router]);
 

--- a/src/utils/redirectIfProduction.ts
+++ b/src/utils/redirectIfProduction.ts
@@ -2,6 +2,6 @@ import { redirect } from 'next/navigation';
 
 export function redirectIfProduction() {
   if (process.env.NEXT_PUBLIC_SITE_MODE === 'production') {
-    redirect('/comingsoon');
+    redirect('/');
   }
 }


### PR DESCRIPTION
## Summary
- update redirects for production mode

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b9a59caa8832da19e8767aa96f669