### PR TITLE
Fix infinite redirect in production

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,6 +1,5 @@
 import Web3ContactForm from "@/components/ContactForm/ContactForm";
 import PageLayout from "@/components/Layouts/PageLayout";
-import { redirectIfProduction } from "@/utils/redirectIfProduction";
 import {
   EnvelopeIcon,
   PhoneIcon,
@@ -22,7 +21,6 @@ export const metadata: Metadata = {
 };
 
 export default function Contact() {
-  redirectIfProduction();
   return (
     <section id="contact" className="scroll-mt-24">
       <PageLayout>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,6 @@ import InfoCard from "@/components/InfoCard/InfoCard";
 import PageLayout from "@/components/Layouts/PageLayout";
 import MenuSection from "@/components/MenuSection/MenuSection";
 import OurStory from "@/components/OurStory/OurStory";
-import { redirectIfProduction } from "@/utils/redirectIfProduction";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -24,7 +23,6 @@ export const metadata: Metadata = {
 };
 
 export default function Home() {
-  redirectIfProduction();
   return (
     <>
       <section id="home" className="relative bg-neutral scroll-mt-24">

--- a/src/utils/redirectIfProduction.ts
+++ b/src/utils/redirectIfProduction.ts
@@ -1,7 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export function redirectIfProduction() {
-  if (process.env.NEXT_PUBLIC_SITE_MODE === 'production') {
-    redirect('/');
-  }
-}


### PR DESCRIPTION
## Summary
- remove unused `redirectIfProduction` logic from site pages
- delete the leftover util file

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b9c549390832da82811e916ba3e45